### PR TITLE
Introduce dynamic demo page

### DIFF
--- a/src/asset/pages.js
+++ b/src/asset/pages.js
@@ -154,17 +154,18 @@ const getPageInforFromPageId = (pageId) => {
 
 /**
  * Get all page information available. Will return -1 if not found.
- * @returns {object} page data of given pageID
+ * @returns {Page[]} page data of given pageID
  */
 const getAllPageInfor = () => {
-  let pageInfor = {};
+  const allPages = [];
+
   for (let { categoryPages } of dictionary) {
     for (let page of categoryPages) {
-      pageInfor[page.pageId] = page;
+      allPages.push(page);
     }
   }
-  if (pageInfor) return pageInfor;
-  else return -1; // Not found
+
+  return allPages;
 };
 
 export default dictionary;

--- a/src/components/Favourites.js
+++ b/src/components/Favourites.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
 import { Modal, Button } from "react-bootstrap";
 
 import Scrollable from "./Scrollable";
@@ -10,13 +11,22 @@ const defaults = [0, 1];
 const all_favourites = getAllPageInfor();
 
 export default function Favourites(props) {
+  const history = useHistory();
   const [favourites, setFavourites] = useState(props.userFavouries || defaults);
   const [pendingFavourites, setPendingFavourites] = useState([]);
   const [isVisibleModal, setVisibleModal] = useState(false);
 
   const currFavourites = favourites.map((id) => {
     const data = getPageInforFromPageId(id);
-    return <FavouriteCard key={id} data={data} />;
+    return (
+      <FavouriteCard
+        key={id}
+        data={data}
+        onClick={() => {
+          history.push(data.pageSlug);
+        }}
+      />
+    );
   });
 
   const allFavourites = Object.keys(all_favourites).map((id) => {

--- a/src/components/RecommendCard.js
+++ b/src/components/RecommendCard.js
@@ -7,7 +7,7 @@ import { IconContext } from "react-icons";
 import styled from "styled-components";
 
 const RecommendCard = (props) => {
-  const { icon, title } = props;
+  const { pageIcon, pageTitle } = props.data;
   const selected = props.selected || false;
   const handleClick = props.onClick;
 
@@ -24,11 +24,13 @@ const RecommendCard = (props) => {
       <Card selected={selected}>
         <IconCircle>
           <IconContext.Provider value={{ color: "white", size: "36px" }}>
-            {React.createElement(FAIcon[icon])}
+            {React.createElement(FAIcon[pageIcon])}
           </IconContext.Provider>
         </IconCircle>
         <h2 className="my-2">
-          {title.length > 25 ? title.substring(0, 25) + "..." : title}
+          {pageTitle.length > 25
+            ? pageTitle.substring(0, 25) + "..."
+            : pageTitle}
         </h2>
       </Card>
     </Wrapper>

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,12 +1,24 @@
 import React from "react";
 import { Route } from "react-router-dom";
+import { getAllPageInfor } from "../asset/pages";
 
 import Home from "../views/Home";
 import Login from "../views/Login";
+import Demo from "../views/Demo";
 import NotFound from "../views/404";
+
+const demoRoutes = getAllPageInfor().map((page) => (
+  <Route
+    exact
+    key={page.pageSlug}
+    path={page.pageSlug}
+    component={() => <Demo title={page.pageTitle} />}
+  />
+));
 
 export default [
   <Route exact key="home" path="/" component={Home} />,
   <Route exact key="login" path="/login" component={Login} />,
+  demoRoutes,
   <Route key="404" path="*" component={NotFound} />,
 ];

--- a/src/views/Demo.js
+++ b/src/views/Demo.js
@@ -1,0 +1,35 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+const Demo = (props) => {
+  const { title, description } = props;
+
+  return (
+    <LandingGreen>
+      <div className="container">
+        <h1>{title}</h1>
+        <p>{description}</p>
+      </div>
+    </LandingGreen>
+  );
+};
+
+Demo.defaultProps = {
+  title: "Demo Page Title",
+  description: "This is a demo page.",
+};
+
+Demo.propTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+};
+
+export default Demo;
+
+const LandingGreen = styled.div`
+  padding: 30px 0;
+  text-align: center;
+
+  background: #e4f9f5;
+`;

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 
 import Scrollable from "../components/Scrollable";
@@ -24,6 +25,7 @@ const LandingGreen = styled.div`
 `;
 
 export default (props) => {
+  const history = useHistory();
   const { currentUser } = useContext(UserContext);
 
   return (
@@ -54,9 +56,16 @@ export default (props) => {
         <SectionHeader header="Recommended" text="These may be useful" />
         <Scrollable>
           {currentUser.recommendations.map((rec, i) => {
-            const { pageIcon, pageTitle } = getPageInforFromPageId(rec);
-
-            return <RecommendCard key={i} icon={pageIcon} title={pageTitle} />;
+            const data = getPageInforFromPageId(rec);
+            return (
+              <RecommendCard
+                key={i}
+                data={data}
+                onClick={() => {
+                  history.push(data.pageSlug);
+                }}
+              />
+            );
           })}
         </Scrollable>
       </Section>


### PR DESCRIPTION
- Introduce new `src\views\Demo.js` page that takes in a title prop as a placeholder for all pages found in `src\asset\pages.js`
- Modify `getAllPageInfor()` to return an array of pages (i.e. `Page[]`) instead of an object
- Favourite and Recommended cards are now linked with their respective slugs